### PR TITLE
feat: add video acceleration env vars

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -12,6 +12,9 @@ package:
     __EGL_VENDOR_LIBRARY_DIRS: $ORIGIN:$PREFIX/glvnd/egl_vendor.d
     LIBGL_DRIVERS_PATH: $ORIGIN:$PREFIX/lib/dri
     GBM_BACKENDS_PATH: $ORIGIN:$PREFIX/lib/gbm
+    LIBVA_DRIVERS_PATH: $ORIGIN:$PREFIX/lib/dri
+    VDPAU_DRIVER_PATH: $ORIGIN:$PREFIX/lib/vdpau
+
 
 permissions:
   innerBinds:

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -12,6 +12,8 @@ package:
     __EGL_VENDOR_LIBRARY_DIRS: $ORIGIN:$PREFIX/glvnd/egl_vendor.d
     LIBGL_DRIVERS_PATH: $ORIGIN:$PREFIX/lib/dri
     GBM_BACKENDS_PATH: $ORIGIN:$PREFIX/lib/gbm
+    LIBVA_DRIVERS_PATH: $ORIGIN:$PREFIX/lib/dri
+    VDPAU_DRIVER_PATH: $ORIGIN:$PREFIX/lib/vdpau
 
 permissions:
   innerBinds:

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -12,6 +12,9 @@ package:
     __EGL_VENDOR_LIBRARY_DIRS: $ORIGIN:$PREFIX/glvnd/egl_vendor.d
     LIBGL_DRIVERS_PATH: $ORIGIN:$PREFIX/lib/dri
     GBM_BACKENDS_PATH: $ORIGIN:$PREFIX/lib/gbm
+    LIBVA_DRIVERS_PATH: $ORIGIN:$PREFIX/lib/dri
+    VDPAU_DRIVER_PATH: $ORIGIN:$PREFIX/lib/vdpau
+
 
 permissions:
   innerBinds:


### PR DESCRIPTION
1. Added LIBVA_DRIVERS_PATH environment variable pointing to $ORIGIN: $PREFIX/lib/dri
2. Added VDPAU_DRIVER_PATH environment variable pointing to $ORIGIN: $PREFIX/lib/vdpau
3. Applied changes to all architecture-specific configurations: arm64, loong64, and generic linglong.yaml files

These environment variables enable hardware video acceleration by allowing the runtime to locate VA-API and VDPAU video drivers within the container environment, which is essential for hardware-accelerated video decoding and encoding.

Log: Enabled hardware video acceleration support for improved video playback performance

Influence:
1. Test video playback with hardware acceleration enabled for various codecs (H.264, H.265, VP9)
2. Verify VA-API functionality using vainfo or vdpauinfo tools
3. Test across all supported architectures: arm64, loong64, and generic
4. Monitor system CPU usage during video playback to confirm hardware acceleration is working
5. Verify video driver loading and check for any missing dependencies in logs
6. Test with multiple video player applications (mpv, VLC, etc.)